### PR TITLE
Require Overture 2.5.2 and VDM2C 0.1.14

### DIFF
--- a/core/fmu-import-export/pom.xml
+++ b/core/fmu-import-export/pom.xml
@@ -7,7 +7,7 @@
 		<version>0.2.9-SNAPSHOT</version>
 	</parent>
 	<properties>
-	<vdm2c.version>0.1.8</vdm2c.version>
+	<vdm2c.version>0.1.14</vdm2c.version>
 	</properties>
 
 	<groupId>org.overturetool.fmi.core</groupId>
@@ -51,11 +51,6 @@
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 			<version>2.4</version>
-		</dependency>
-		<dependency>
-			<groupId>org.overturetool.core</groupId>
-			<artifactId>typechecker</artifactId>
-			<version>2.4.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.overturetool.vdm2c.core</groupId>

--- a/ide/fmu-export/META-INF/MANIFEST.MF
+++ b/ide/fmu-export/META-INF/MANIFEST.MF
@@ -9,8 +9,8 @@ Bundle-SymbolicName: org.overture.fmi.ide.fmuexport;singleton:=true
 Require-Bundle: org.eclipse.ui.console,
  org.overture.ide.ui,
  org.overture.ide.core,
- org.overture.ide.builders.vdmj;bundle-version="2.0.0",
- org.overturetool.vdm2c.ide.cgen;bundle-version="0.0.3"
+ org.overture.ide.builders.vdmj;bundle-version="2.5.2",
+ org.overturetool.vdm2c.ide.cgen;bundle-version="0.1.14"
 Bundle-Activator: org.overture.fmi.ide.fmuexport.FmuExportPlugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .,


### PR DESCRIPTION
The purpose of this pull request is to make the FMU exporter's dependencies match those of VDM2C and Crescendo.

By merging this pull request, Eclipse will help ensure that the plugin uses the right dependency versions